### PR TITLE
fixed error on update user

### DIFF
--- a/ios/Classes/SwiftChannelTalkFlutterPlugin.swift
+++ b/ios/Classes/SwiftChannelTalkFlutterPlugin.swift
@@ -234,7 +234,7 @@ public class SwiftChannelTalkFlutterPlugin: NSObject, FlutterPlugin {
       .build()
 
     ChannelIO.updateUser(param: userData) { (error, user) in
-      if let _ = user, error != nil {
+      if let _ = user, user != nil {
         result(true)
       } else if let error = error {
         NSLog(error.localizedDescription)


### PR DESCRIPTION
Consider flutter code:

```
await ChannelTalk.updateUser(name: "USER_NAME");
await ChannelTalk.showMessenger();
```

Because of `let _ = user, error != nil` in Swift code, ChannelTalk.updateUser failed without any message even if nothing was wrong. This fix addresses this problem.

Fixes https://github.com/turlvo/channel_talk_flutter/issues/4