### PR TITLE
Support anonymous users

### DIFF
--- a/android/src/main/java/ai/deepnatural/channel_talk/ChannelTalkFlutterPlugin.java
+++ b/android/src/main/java/ai/deepnatural/channel_talk/ChannelTalkFlutterPlugin.java
@@ -154,11 +154,6 @@ public class ChannelTalkFlutterPlugin implements FlutterPlugin, MethodCallHandle
       result.error("UNAVAILABLE", "Missing argument(pluginKey)", null);
       return;
     }
-    String memberHash = call.argument("memberHash");
-    if (memberHash == null || memberHash.isEmpty()) {
-      result.error("UNAVAILABLE", "Missing argument(memberHash)", null);
-      return;
-    }
 
     Profile profile = Profile.create();
     if (call.argument("email") != null) {
@@ -178,8 +173,10 @@ public class ChannelTalkFlutterPlugin implements FlutterPlugin, MethodCallHandle
     );
 
     BootConfig bootConfig = BootConfig.create(pluginKey)
-            .setProfile(profile)
-            .setMemberHash(memberHash);
+            .setProfile(profile);
+    if (call.argument("memberHash") != null) {
+      bootConfig.setMemberHash(call.argument("memberHash"));
+    }
     if (call.argument("memberId") != null) {
       bootConfig.setMemberId(call.argument("memberId"));
     }

--- a/ios/Classes/SwiftChannelTalkFlutterPlugin.swift
+++ b/ios/Classes/SwiftChannelTalkFlutterPlugin.swift
@@ -63,8 +63,7 @@ public class SwiftChannelTalkFlutterPlugin: NSObject, FlutterPlugin {
 
   private func boot(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
     guard let argMaps = call.arguments as? Dictionary<String, Any>, 
-      let pluginKey = argMaps["pluginKey"] as? String,
-      let memberHash = argMaps["memberHash"] as? String else {
+      let pluginKey = argMaps["pluginKey"] as? String else {
       result(FlutterError(code: call.method, message: "Missing argument", details: nil))
       return
     }
@@ -86,6 +85,7 @@ public class SwiftChannelTalkFlutterPlugin: NSObject, FlutterPlugin {
       yMargin: 23
     )
 
+    let memberHash = argMaps["memberHash"] as? String
     let memberId = argMaps["memberId"] as? String
     let trackDefaultEvent = argMaps["trackDefaultEvent"] as? Bool
     let hidePopup = argMaps["hidePopup"] as? Bool

--- a/lib/channel_talk_flutter.dart
+++ b/lib/channel_talk_flutter.dart
@@ -12,7 +12,7 @@ class ChannelTalk {
 
   static Future<bool?> boot({
     required String pluginKey,
-    required String memberHash,
+    String? memberHash,
     String? memberId,
     String? email,
     String? name,
@@ -23,9 +23,11 @@ class ChannelTalk {
   }) {
     Map<String, dynamic> config = {
       'pluginKey': pluginKey,
-      'memberHash': memberHash,
     };
 
+    if (memberHash != null) {
+      config['memberHash'] = memberHash;
+    }
     if (memberId != null) {
       config['memberId'] = memberId;
     }


### PR DESCRIPTION
Channel Talk does not require `memberHash` for anonymous users.
But this plugin requires a `memberHash`.
This PR changes `memberHash` to optional.