### PR TITLE
docs: README.md의 Push notifications 가이드 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ This plugin works in combination with the [`firebase_messaging`](https://pub.dev
 
 ```
     <service
-        android:name="ai.deepnatural.channel_talk.PushInterceptService"
+        android:name="com.kuku.channel_talk_flutter.PushInterceptService"
         android:enabled="true"
         android:exported="true">
         <intent-filter>


### PR DESCRIPTION
혹여나 해당 가이드를 그대로 따라하여 빌드 하는분이 있을까 걱정되어 문서 수정도 요청드립니다. 
Android 에서 PushInterceptService 의 경로를 찾지 못하여 네이티브 에러가 발생할 것으로 보입니다. 

channel_talk_flutter 에서 Android 프로젝트의 패키지명이 변경되었습니다. 
따라서 Android 의 PushInterceptService 의 패키지 경로도 변경하도록 가이드하는게 좋을거 같아 내용을 수정하였습니다 ~
