### PR TITLE
Update compileSdkVersion to Resolve Android Build Error after Flutter 3.24 Upgrade

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -24,7 +24,7 @@ apply plugin: 'com.android.library'
 android {
     namespace "com.kuku.channel_talk_flutter"
 
-    compileSdkVersion 31
+    compileSdkVersion 34
 
     defaultConfig {
         minSdkVersion 19


### PR DESCRIPTION
## Summary

After upgrading to Flutter version 3.24, I encountered the following error when running flutter build apk on Android.

```
Execution failed for task ':channel_talk_flutter:verifyProfileResources'.
> A failure occurred while executing com.android.build.gradle.tasks.VerifyLibraryResourcesTask$Action
   > Android resource linking failed
     ERROR: /Users/user/projects/flutter_example/build/channel_talk_flutter/intermediates/merged_res/profile/mergeProfileResources/values-v34/values-v34.xml:3: AAPT: error: resource android:color/system_background_dark not found.
```

## Solution

This issue was resolved by updating the compileSdkVersion to the latest version.

## Changes

- Updated compileSdkVersion to the latest version.

Please review and let me know if any further changes are required.