### PR TITLE
Fix Issue: App not launching when tapping on Push Notification

### DIFF
--- a/android/src/main/java/com/kuku/channel_talk_flutter/ChannelTalkFlutterHandler.java
+++ b/android/src/main/java/com/kuku/channel_talk_flutter/ChannelTalkFlutterHandler.java
@@ -66,11 +66,8 @@ class ChannelTalkFlutterHandler implements ChannelPluginListener {
 
     @Override
     public boolean onPushNotificationClicked(String chatId) {
-        if (chatId == null) {
-            return false;
-        }
         channel.invokeMethod("onPushNotificationClicked", chatId);
-        return true;
+        return false;
     }
 
 }


### PR DESCRIPTION
## Summary:
This PR fixes an issue where tapping on a Push notification does not launch the app on Android.

## Issue Details:
- When the app is not completely closed, tapping on a Push notification opens the app as expected.
- However, when the app is minimized and in the background, tapping the Push notification does not launch the app.

## Fix:
- The return value of onPushNotificationClicked was changed from true to false, ensuring that the app launches correctly when minimized and a Push notification is tapped.

## Request for Feedback:

I would appreciate any feedback on potential side effects of setting the return value of onPushNotificationClicked to false. As of now, no major issues are anticipated, but please let me know if there are any concerns.

---
By submitting this PR, I hope to resolve the issue related to Push notifications not launching the app as expected.
Let me know if you need any further modifications!