### PR TITLE
feat: URL 클릭 처리 제어를 위한 setPreventDefaultUrlClick API 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -679,6 +679,19 @@ It is valid when creating a new user. The language of the user that already exis
             <td></td>
             <td>Mobile</td>
         </tr>
+        <!-- setPreventDefaultUrlClick -->
+        <tr>
+            <td>setPreventDefaultUrlClick</td>
+            <td>
+                Overrides Channel Talk’s default URL click behavior. When enabled, clicks are passed to the app’s onUrlClicked listener instead of opening in the browser.
+            </td>
+            <td>prevent*</td>
+            <td>bool</td>
+            <td>
+                If true, URL clicks will be delegated to the app's listener through onUrlClicked event instead of opening in the default browser. If false, URLs will open in the default browser as normal.
+            </td>
+            <td>Mobile</td>
+        </tr>
     </tbody>
 </table>
 

--- a/android/src/main/java/com/kuku/channel_talk_flutter/ChannelTalkFlutterHandler.java
+++ b/android/src/main/java/com/kuku/channel_talk_flutter/ChannelTalkFlutterHandler.java
@@ -10,9 +10,14 @@ import java.util.Map;
 
 class ChannelTalkFlutterHandler implements ChannelPluginListener {
     private MethodChannel channel;
+    private boolean preventDefaultUrlClick = false;
 
     public ChannelTalkFlutterHandler(MethodChannel methodChannel) {
         channel = methodChannel;
+    }
+    
+    public void setPreventDefaultUrlClick(boolean prevent) {
+        this.preventDefaultUrlClick = prevent;
     }
 
     @Override
@@ -51,7 +56,7 @@ class ChannelTalkFlutterHandler implements ChannelPluginListener {
     @Override
     public boolean onUrlClicked(String url) {
         channel.invokeMethod("onUrlClicked", url);
-        return false;
+        return preventDefaultUrlClick;
     }
 
     @Override

--- a/android/src/main/java/com/kuku/channel_talk_flutter/ChannelTalkFlutterPlugin.java
+++ b/android/src/main/java/com/kuku/channel_talk_flutter/ChannelTalkFlutterPlugin.java
@@ -117,6 +117,8 @@ public class ChannelTalkFlutterPlugin implements FlutterPlugin, MethodCallHandle
       setAppearance(call, result);
     } else if (call.method.equals("hidePopup")) {
       hidePopup(call, result);
+    } else if (call.method.equals("setPreventDefaultUrlClick")) {
+      setPreventDefaultUrlClick(call, result);
     } else {
       result.notImplemented();
     }
@@ -481,6 +483,17 @@ public class ChannelTalkFlutterPlugin implements FlutterPlugin, MethodCallHandle
 
   public void hidePopup(@NonNull MethodCall call, @NonNull final Result result) {
     ChannelIO.hidePopup();
+    result.success(true);
+  }
+  
+  public void setPreventDefaultUrlClick(@NonNull MethodCall call, @NonNull final Result result) {
+    Boolean prevent = call.argument("prevent");
+    if (prevent == null) {
+      result.error("UNAVAILABLE", "Missing argument(prevent)", null);
+      return;
+    }
+    
+    channelTalkEventHandler.setPreventDefaultUrlClick(prevent);
     result.success(true);
   }
 

--- a/ios/Classes/ChannelTalkFlutterHandler.swift
+++ b/ios/Classes/ChannelTalkFlutterHandler.swift
@@ -4,9 +4,14 @@ import ChannelIOFront
 
 public class ChannelTalkFlutterHandler: NSObject, ChannelPluginDelegate {
     var channel : FlutterMethodChannel
+    private var preventDefaultUrlClick: Bool = false
     
     init (channel: FlutterMethodChannel) {
         self.channel = channel
+    }
+    
+    public func setPreventDefaultUrlClick(_ prevent: Bool) {
+        self.preventDefaultUrlClick = prevent
     }
 
 
@@ -36,7 +41,7 @@ public class ChannelTalkFlutterHandler: NSObject, ChannelPluginDelegate {
 
     public func onUrlClicked(url: URL) -> Bool {
         channel.invokeMethod("onUrlClicked", arguments: url.absoluteString)
-        return false
+        return preventDefaultUrlClick
     }
 
     public func onPopupDataReceived(event: PopupData) {

--- a/ios/Classes/ChannelTalkFlutterPlugin.swift
+++ b/ios/Classes/ChannelTalkFlutterPlugin.swift
@@ -67,6 +67,8 @@ public class ChannelTalkFlutterPlugin: NSObject, FlutterPlugin {
         self.setAppearance(call, result)
       case "hidePopup":
         self.hidePopup(call, result)
+      case "setPreventDefaultUrlClick":
+        self.setPreventDefaultUrlClick(call, result)
       
       default:
         result(FlutterMethodNotImplemented)
@@ -414,6 +416,17 @@ public class ChannelTalkFlutterPlugin: NSObject, FlutterPlugin {
 
   private func hidePopup(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
     ChannelIO.hidePopup()
+    result(true)
+  }
+  
+  private func setPreventDefaultUrlClick(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
+    guard let argMaps = call.arguments as? Dictionary<String, Any>,
+      let prevent = argMaps["prevent"] as? Bool else {
+      result(FlutterError(code: call.method, message: "Missing argument", details: nil))
+      return
+    }
+    
+    channelTalkEventHandler?.setPreventDefaultUrlClick(prevent)
     result(true)
   }
 

--- a/lib/channel_talk_flutter.dart
+++ b/lib/channel_talk_flutter.dart
@@ -262,4 +262,11 @@ class ChannelTalk {
   static Future<bool?> hidePopup() {
     return ChannelTalkFlutterPlatform.instance.hidePopup();
   }
+
+  static Future<bool?> setPreventDefaultUrlClick({
+    required bool prevent,
+  }) {
+    return ChannelTalkFlutterPlatform.instance
+        .setPreventDefaultUrlClick(prevent);
+  }
 }

--- a/lib/channel_talk_flutter_method_channel.dart
+++ b/lib/channel_talk_flutter_method_channel.dart
@@ -229,4 +229,11 @@ class MethodChannelChannelTalkFlutter extends ChannelTalkFlutterPlatform {
   Future<bool?> hidePopup() {
     return methodChannel.invokeMethod('hidePopup');
   }
+
+  @override
+  Future<bool?> setPreventDefaultUrlClick(bool prevent) {
+    return methodChannel.invokeMethod('setPreventDefaultUrlClick', {
+      'prevent': prevent,
+    });
+  }
 }

--- a/lib/channel_talk_flutter_platform_interface.dart
+++ b/lib/channel_talk_flutter_platform_interface.dart
@@ -170,4 +170,9 @@ abstract class ChannelTalkFlutterPlatform extends PlatformInterface {
   Future<bool?> hidePopup() {
     throw UnimplementedError('hidePopup() has not been implemented.');
   }
+
+  Future<bool?> setPreventDefaultUrlClick(bool prevent) {
+    throw UnimplementedError(
+        'setPreventDefaultUrlClick() has not been implemented.');
+  }
 }


### PR DESCRIPTION
## 📝 개요
채널톡의 기본 URL 클릭 동작을 제어할 수 있는 `setPreventDefaultUrlClick` API를 추가했습니다.

## 🎯 배경
- 채널톡 채팅창에서 URL 클릭 시 항상 기본 브라우저가 열림
- 앱에서 URL 클릭 이벤트를 직접 처리하고 싶은 경우가 있음

## ✨ 변경사항

### 새로운 API 추가
- `ChannelTalk.setPreventDefaultUrlClick({required bool prevent})` 메서드 추가

### API 동작 방식
채널톡의 기본 URL 클릭 동작을 재정의할지 여부를 제어합니다. 활성화하면 URL 클릭 이벤트가 SDK의 기본 브라우저 동작 대신 리스너로 위임됩니다.

**파라미터:**
- `prevent` (bool, 필수): 
  - `true`: URL 클릭 시 기본 브라우저가 열리지 않고, 앱의 리스너를 통해 `onUrlClicked` 이벤트로만 전달
  - `false`: URL이 기본 브라우저에서 정상적으로 열림 (기본 동작)

## 💡 하위 호환성
**Breaking Changes 없음** - 기본값이 `false`로 설정되어 기존 동작을 그대로 유지합니다.
