### PR TITLE
feat: add optional profile parameter to setPage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Unreleased
+- Added optional `profile` parameter to `setPage` API
+
 ## 4.2.0
 - Upgrade iOS's ChannelIOSdk version to 13.0.2
 - Upgrade Android's ChannelIOSdk version to 13.1.0

--- a/README.md
+++ b/README.md
@@ -611,12 +611,17 @@ It is valid when creating a new user. The language of the user that already exis
         </tr>
         <!-- setPage -->
         <tr>
-            <td>setPage</td>
-            <td>Sets the name of the screen when the track is called.</td>
+            <td rowspan=2>setPage</td>
+            <td rowspan=2>Sets the name of the screen when the track is called.</td>
             <td>page*</td>
             <td>String</td>
             <td>This is the screen name when track is called.</td>
-            <td>Mobile, Web</td>
+            <td rowspan=2>Mobile, Web</td>
+        </tr>
+        <tr>
+            <td>profile</td>
+            <td>Map?</td>
+            <td>Profile values applied to the user chat, applied when the chat is created. If a field is set to null, only that field's value is cleared.</td>
         </tr>
         <!-- resetPage -->
         <tr>

--- a/android/src/main/java/com/kuku/channel_talk_flutter/ChannelTalkFlutterPlugin.java
+++ b/android/src/main/java/com/kuku/channel_talk_flutter/ChannelTalkFlutterPlugin.java
@@ -416,7 +416,12 @@ public class ChannelTalkFlutterPlugin implements FlutterPlugin, MethodCallHandle
       result.error("UNAVAILABLE", "Missing argument(page)", null);
       return;
     }
-    ChannelIO.setPage(page);
+    Map<String, Object> profile = call.argument("profile");
+    if (profile != null && !profile.isEmpty()) {
+      ChannelIO.setPage(page, profile);
+    } else {
+      ChannelIO.setPage(page);
+    }
     result.success(true);
   }
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -759,7 +759,8 @@ class _MyAppState extends State<MyApp> {
                 onPressed: () async {
                   content = '''
 {
-  "page": "Custom Value"
+  "page": "Custom Value",
+  "profile": { "name": "John Doe", "email": "john@example.com" }
 }
                   ''';
 
@@ -769,8 +770,10 @@ class _MyAppState extends State<MyApp> {
                       Map args = json.decode(content);
 
                       try {
-                        final result =
-                            await ChannelTalk.setPage(page: args['page']);
+                        final result = await ChannelTalk.setPage(
+                          page: args['page'],
+                          profile: (args['profile'] as Map?)?.cast<String, dynamic>(),
+                        );
 
                         showMessageToast('Result: $result');
                       } on PlatformException catch (error) {

--- a/ios/Classes/ChannelTalkFlutterPlugin.swift
+++ b/ios/Classes/ChannelTalkFlutterPlugin.swift
@@ -350,7 +350,12 @@ public class ChannelTalkFlutterPlugin: NSObject, FlutterPlugin {
       return
     }
     
-    ChannelIO.setPage(page)
+    let profile = argMaps["profile"] as? [String: Any]
+    if let profile = profile, !profile.isEmpty {
+      ChannelIO.setPage(page, profile: profile)
+    } else {
+      ChannelIO.setPage(page)
+    }
     result(true)
   }
 

--- a/lib/channel_talk_flutter.dart
+++ b/lib/channel_talk_flutter.dart
@@ -222,8 +222,8 @@ class ChannelTalk {
     return ChannelTalkFlutterPlatform.instance.setDebugMode(flag);
   }
 
-  static Future<bool?> setPage({required page}) {
-    return ChannelTalkFlutterPlatform.instance.setPage(page);
+  static Future<bool?> setPage({required page, Map<String, dynamic>? profile}) {
+    return ChannelTalkFlutterPlatform.instance.setPage(page, profile);
   }
 
   static Future<bool?> resetPage() {

--- a/lib/channel_talk_flutter_method_channel.dart
+++ b/lib/channel_talk_flutter_method_channel.dart
@@ -184,9 +184,10 @@ class MethodChannelChannelTalkFlutter extends ChannelTalkFlutterPlatform {
   }
 
   @override
-  Future<bool?> setPage(String page) {
+  Future<bool?> setPage(String page, [Map<String, dynamic>? profile]) {
     return methodChannel.invokeMethod('setPage', {
       'page': page,
+      if (profile != null) 'profile': profile,
     });
   }
 

--- a/lib/channel_talk_flutter_platform_interface.dart
+++ b/lib/channel_talk_flutter_platform_interface.dart
@@ -141,7 +141,7 @@ abstract class ChannelTalkFlutterPlatform extends PlatformInterface {
     throw UnimplementedError('setDebugMode() has not been implemented.');
   }
 
-  Future<bool?> setPage(String page) {
+  Future<bool?> setPage(String page, [Map<String, dynamic>? profile]) {
     throw UnimplementedError('setPage() has not been implemented.');
   }
 

--- a/lib/channel_talk_flutter_web.dart
+++ b/lib/channel_talk_flutter_web.dart
@@ -163,8 +163,13 @@ class ChannelTalkFlutterWeb extends ChannelTalkFlutterPlatform {
   }
 
   @override
-  Future<bool?> setPage(page) {
-    channel_talk_service.setPage('setPage', page);
+  Future<bool?> setPage(page, [Map<String, dynamic>? profile]) {
+    final hasProfile = profile != null && profile.isNotEmpty;
+    channel_talk_service.setPage(
+      'setPage',
+      page,
+      hasProfile ? profile.jsify() : null,
+    );
     return Future.value(true);
   }
 

--- a/lib/web/channel_io_service.dart
+++ b/lib/web/channel_io_service.dart
@@ -112,7 +112,7 @@ external void updateUser(
 );
 
 @JS('ChannelIO')
-external void setPage(String command, String page);
+external void setPage(String command, String page, JSAny? profile);
 
 @JS('ChannelIO')
 external void resetPage(String command);


### PR DESCRIPTION
## 개요

ChannelIO의 iOS / Android / Web SDK는 이미 `setPage`에서 접객 채팅 프로필 값을 설정하는 `profile` 인자를 지원하지만, 본 플러그인은 이 인자를 노출하고 있지 않습니다. 이 PR은 `setPage`에 optional `profile` 파라미터를 추가해 네이티브 SDK 기능을 그대로 사용할 수 있게 합니다.

## 변경 내용

- `setPage`에 optional `profile`(`Map<String, dynamic>?`)을 추가했습니다. `page`는 기존과 동일하게 필수이므로 **하위호환이 유지**됩니다.
- 전 레이어에 반영했습니다: 공개 API → platform interface → method channel → iOS(Swift) / Android(Java) / Web(JS interop).
- 기존 `track` / `updateUser`의 Map 전달 패턴을 그대로 따랐습니다.

## 동작 규칙

- `profile`이 `null`이거나 빈 맵이면 네이티브 SDK에 profile을 전달하지 않고 기존 page-only 호출로 동작합니다(빈 객체를 강제로 넘기지 않음).
- iOS: `ChannelIO.setPage(page, profile:)` — profile이 비어있지 않을 때만
- Android: `ChannelIO.setPage(page, profile)` 오버로드 — profile이 비어있지 않을 때만
- Web: `ChannelIO('setPage', page, profile)`

## SDK 버전

ChannelIO SDK 버전 변경은 없습니다. 현재 pin된 iOS `13.0.2`, Android `13.1.0`이 이미 `profile` 인자를 지원합니다.

## 검증

- `flutter analyze` 통과
- example 앱 iOS 빌드 성공(Swift 컴파일 확인)
- example의 setPage 데모에 profile 페이로드를 추가했습니다.

## 참고 문서

- iOS: https://developers.channel.io/ja/articles/ChannelIO-a403bd1c#setpage
- Android: https://developers.channel.io/ja/articles/ChannelIO-e9706bcd#setpage
