### PR TITLE
feat: add bootWithStatus returning ChannelTalkBootStatus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Unreleased
+- Added `bootWithStatus()` returning `ChannelTalkBootStatus` (the detailed boot result). `boot()` is unchanged and now delegates to the same native path.
 - Added optional `profile` parameter to `setPage` API
 
 ## 4.2.0

--- a/README.md
+++ b/README.md
@@ -93,6 +93,23 @@ class App extends StatelessWidget {
 
 See Channel Talk Android and iOS package documentation for more information.
 
+### Boot with status
+
+`boot()` returns `true` only on success. To tell *why* a boot failed — e.g. to
+retry a transient `networkTimeout` but give up on a permanent `accessDenied` —
+use `bootWithStatus()`, which resolves to a `ChannelTalkBootStatus` (`success`,
+`notInitialized`, `networkTimeout`, `notAvailableVersion`,
+`serviceUnderConstruction`, `requirePayment`, `accessDenied`, `unknown`). It
+takes the same arguments as `boot()` and shares the same native boot path. On
+web, a completed boot resolves to `success`.
+
+```dart
+final status = await ChannelTalk.bootWithStatus(pluginKey: 'pluginKey');
+if (status != ChannelTalkBootStatus.success) {
+  // inspect `status` and decide whether to retry
+}
+```
+
 ### iOS
 
 Update info.plist.

--- a/android/src/main/java/com/kuku/channel_talk_flutter/ChannelTalkFlutterPlugin.java
+++ b/android/src/main/java/com/kuku/channel_talk_flutter/ChannelTalkFlutterPlugin.java
@@ -69,6 +69,8 @@ public class ChannelTalkFlutterPlugin implements FlutterPlugin, MethodCallHandle
   public void onMethodCall(@NonNull MethodCall call, @NonNull final Result result) {
     if (call.method.equals("boot")) {
       boot(call, result);
+    } else if (call.method.equals("bootWithStatus")) {
+      bootWithStatus(call, result);
     } else if (call.method.equals("sleep")) {
       sleep(call, result);
     } else if (call.method.equals("shutdown")) {
@@ -161,7 +163,26 @@ public class ChannelTalkFlutterPlugin implements FlutterPlugin, MethodCallHandle
     // Clean up references.
   }
 
+  private interface OnBootStatus {
+    void onStatus(String status);
+  }
+
   public void boot(@NonNull MethodCall call, @NonNull final Result result) {
+    performBoot(call, result, status -> {
+      if ("success".equals(status)) {
+        result.success(true);
+      } else {
+        result.error("ERROR", "Execution failed(boot)", null);
+      }
+    });
+  }
+
+  public void bootWithStatus(@NonNull MethodCall call, @NonNull final Result result) {
+    performBoot(call, result, status -> result.success(status));
+  }
+
+  private void performBoot(@NonNull MethodCall call, @NonNull final Result result,
+      @NonNull final OnBootStatus onStatus) {
     String pluginKey = call.argument("pluginKey");
     if (pluginKey == null || pluginKey.isEmpty()) {
       result.error("UNAVAILABLE", "Missing argument(pluginKey)", null);
@@ -219,12 +240,30 @@ public class ChannelTalkFlutterPlugin implements FlutterPlugin, MethodCallHandle
       public void onComplete(BootStatus bootStatus, @Nullable User user) {
         if (bootStatus == BootStatus.SUCCESS && user != null) {
           ChannelIO.setListener(channelTalkEventHandler);
-          result.success(true);
-        } else {
-          result.error("ERROR", "Execution failed(boot)", null);
         }
+        onStatus.onStatus(bootStatusString(bootStatus, user));
       }
     });
+  }
+
+  private String bootStatusString(BootStatus status, @Nullable User user) {
+    if (status == BootStatus.SUCCESS) {
+      return user != null ? "success" : "unknown";
+    } else if (status == BootStatus.NOT_INITIALIZED) {
+      return "notInitialized";
+    } else if (status == BootStatus.NETWORK_TIMEOUT) {
+      return "networkTimeout";
+    } else if (status == BootStatus.NOT_AVAILABLE_VERSION) {
+      return "notAvailableVersion";
+    } else if (status == BootStatus.SERVICE_UNDER_CONSTRUCTION) {
+      return "serviceUnderConstruction";
+    } else if (status == BootStatus.REQUIRE_PAYMENT) {
+      return "requirePayment";
+    } else if (status == BootStatus.ACCESS_DENIED) {
+      return "accessDenied";
+    } else {
+      return "unknown";
+    }
   }
 
   public void sleep(@NonNull MethodCall call, @NonNull final Result result) {

--- a/ios/Classes/ChannelTalkFlutterPlugin.swift
+++ b/ios/Classes/ChannelTalkFlutterPlugin.swift
@@ -19,6 +19,8 @@ public class ChannelTalkFlutterPlugin: NSObject, FlutterPlugin {
     switch call.method {
       case "boot":
         self.boot(call, result)
+      case "bootWithStatus":
+        self.bootWithStatus(call, result)
       case "sleep":
         self.sleep(call, result)
       case "shutdown":
@@ -76,6 +78,22 @@ public class ChannelTalkFlutterPlugin: NSObject, FlutterPlugin {
   }
 
   private func boot(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
+    performBoot(call, result) { statusString in
+      result(statusString == "success")
+    }
+  }
+
+  private func bootWithStatus(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
+    performBoot(call, result) { statusString in
+      result(statusString)
+    }
+  }
+
+  private func performBoot(
+    _ call: FlutterMethodCall,
+    _ result: @escaping FlutterResult,
+    onStatus: @escaping (String) -> Void
+  ) {
     guard let argMaps = call.arguments as? Dictionary<String, Any>,
       let pluginKey = argMaps["pluginKey"] as? String else {
       result(FlutterError(code: call.method, message: "Missing argument", details: nil))
@@ -140,16 +158,36 @@ public class ChannelTalkFlutterPlugin: NSObject, FlutterPlugin {
     )
 
     ChannelIO.boot(with: bootConfig) { (completion, user) in
-      if completion == .success, let _ = user {
-        // Success
+      if completion == .success, user != nil {
         ChannelIO.delegate = self.channelTalkEventHandler
-        result(true)
-      } else {
-        // Fail
-        result(false)
-        // result(FlutterError(code: call.method, message: self.getBootErrorMessage(status: completion), details: nil))
-
       }
+      onStatus(self.bootStatusString(completion, hasUser: user != nil))
+    }
+  }
+
+  /// Maps the native `BootStatus` to the string contract shared with the Dart
+  /// `ChannelTalkBootStatus` enum. A `.success` with no user is reported as
+  /// `unknown`, matching `boot`'s stricter success requirement.
+  private func bootStatusString(_ status: BootStatus, hasUser: Bool) -> String {
+    switch status {
+      case .success:
+        return hasUser ? "success" : "unknown"
+      case .notInitialized:
+        return "notInitialized"
+      case .networkTimeout:
+        return "networkTimeout"
+      case .notAvailableVersion:
+        return "notAvailableVersion"
+      case .serviceUnderConstruction:
+        return "serviceUnderConstruction"
+      case .requirePayment:
+        return "requirePayment"
+      case .accessDenied:
+        return "accessDenied"
+      case .unknown:
+        return "unknown"
+      default:
+        return "unknown"
     }
   }
 

--- a/lib/channel_talk_flutter.dart
+++ b/lib/channel_talk_flutter.dart
@@ -21,6 +21,38 @@ enum Language {
   final String value;
 }
 
+/// The outcome of [ChannelTalk.bootWithStatus], mirroring the native ChannelIO
+/// `BootStatus`.
+///
+/// [ChannelTalk.boot] collapses this to `success`; [ChannelTalk.bootWithStatus]
+/// preserves the reason so callers can tell transient failures (e.g.
+/// [networkTimeout], retryable) from permanent ones (e.g. [accessDenied]).
+enum ChannelTalkBootStatus {
+  success('success'),
+  notInitialized('notInitialized'),
+  networkTimeout('networkTimeout'),
+  notAvailableVersion('notAvailableVersion'),
+  serviceUnderConstruction('serviceUnderConstruction'),
+  requirePayment('requirePayment'),
+  accessDenied('accessDenied'),
+  unknown('unknown');
+
+  const ChannelTalkBootStatus(this.value);
+
+  final String value;
+
+  /// Maps a native status string to a [ChannelTalkBootStatus], defaulting to
+  /// [unknown] for null or any unrecognized value.
+  static ChannelTalkBootStatus fromNative(String? value) {
+    for (final status in ChannelTalkBootStatus.values) {
+      if (status.value == value) {
+        return status;
+      }
+    }
+    return ChannelTalkBootStatus.unknown;
+  }
+}
+
 class ChannelTalk {
   static void setListener(ChannelTalkDelegate delegate) {
     return ChannelTalkFlutterPlatform.instance.setListener(delegate);
@@ -29,6 +61,38 @@ class ChannelTalk {
   // Removes the callback listener if it exists
   static void removeListener() {
     return ChannelTalkFlutterPlatform.instance.removeListener();
+  }
+
+  static Map<String, dynamic> _buildBootConfig({
+    required String pluginKey,
+    String? memberId,
+    String? memberHash,
+    String? email,
+    String? name,
+    String? mobileNumber,
+    String? avatarUrl,
+    Language? language,
+    bool? unsubscribeEmail,
+    bool? unsubscribeTexting,
+    bool? trackDefaultEvent,
+    bool? hidePopup,
+    Appearance? appearance,
+  }) {
+    return {
+      'pluginKey': pluginKey,
+      if (memberId != null) 'memberId': memberId,
+      if (memberHash != null) 'memberHash': memberHash,
+      if (email != null) 'email': email,
+      if (name != null) 'name': name,
+      if (mobileNumber != null) 'mobileNumber': mobileNumber,
+      if (avatarUrl != null) 'avatarUrl': avatarUrl,
+      if (language != null) 'language': language.value,
+      if (unsubscribeEmail != null) 'unsubscribeEmail': unsubscribeEmail,
+      if (unsubscribeTexting != null) 'unsubscribeTexting': unsubscribeTexting,
+      if (trackDefaultEvent != null) 'trackDefaultEvent': trackDefaultEvent,
+      if (hidePopup != null) 'hidePopup': hidePopup,
+      if (appearance != null) 'appearance': appearance.value,
+    };
   }
 
   static Future<bool?> boot({
@@ -46,23 +110,65 @@ class ChannelTalk {
     bool? hidePopup,
     Appearance? appearance,
   }) {
-    Map<String, dynamic> config = {
-      'pluginKey': pluginKey,
-      if (memberId != null) 'memberId': memberId,
-      if (memberHash != null) 'memberHash': memberHash,
-      if (email != null) 'email': email,
-      if (name != null) 'name': name,
-      if (mobileNumber != null) 'mobileNumber': mobileNumber,
-      if (avatarUrl != null) 'avatarUrl': avatarUrl,
-      if (language != null) 'language': language.value,
-      if (unsubscribeEmail != null) 'unsubscribeEmail': unsubscribeEmail,
-      if (unsubscribeTexting != null) 'unsubscribeTexting': unsubscribeTexting,
-      if (trackDefaultEvent != null) 'trackDefaultEvent': trackDefaultEvent,
-      if (hidePopup != null) 'hidePopup': hidePopup,
-      if (appearance != null) 'appearance': appearance.value,
-    };
+    return ChannelTalkFlutterPlatform.instance.boot(
+      _buildBootConfig(
+        pluginKey: pluginKey,
+        memberId: memberId,
+        memberHash: memberHash,
+        email: email,
+        name: name,
+        mobileNumber: mobileNumber,
+        avatarUrl: avatarUrl,
+        language: language,
+        unsubscribeEmail: unsubscribeEmail,
+        unsubscribeTexting: unsubscribeTexting,
+        trackDefaultEvent: trackDefaultEvent,
+        hidePopup: hidePopup,
+        appearance: appearance,
+      ),
+    );
+  }
 
-    return ChannelTalkFlutterPlatform.instance.boot(config);
+  /// Boots ChannelTalk like [boot], but resolves to the detailed
+  /// [ChannelTalkBootStatus] instead of collapsing it to a bool.
+  ///
+  /// [boot] returns `true` only for [ChannelTalkBootStatus.success]; use this
+  /// when you need to distinguish a transient failure (e.g.
+  /// [ChannelTalkBootStatus.networkTimeout], retryable) from a permanent one
+  /// (e.g. [ChannelTalkBootStatus.accessDenied]). On web, which does not surface
+  /// a boot status, a completed boot resolves to [ChannelTalkBootStatus.success].
+  static Future<ChannelTalkBootStatus> bootWithStatus({
+    required String pluginKey,
+    String? memberId,
+    String? memberHash,
+    String? email,
+    String? name,
+    String? mobileNumber,
+    String? avatarUrl,
+    Language? language,
+    bool? unsubscribeEmail,
+    bool? unsubscribeTexting,
+    bool? trackDefaultEvent,
+    bool? hidePopup,
+    Appearance? appearance,
+  }) {
+    return ChannelTalkFlutterPlatform.instance.bootWithStatus(
+      _buildBootConfig(
+        pluginKey: pluginKey,
+        memberId: memberId,
+        memberHash: memberHash,
+        email: email,
+        name: name,
+        mobileNumber: mobileNumber,
+        avatarUrl: avatarUrl,
+        language: language,
+        unsubscribeEmail: unsubscribeEmail,
+        unsubscribeTexting: unsubscribeTexting,
+        trackDefaultEvent: trackDefaultEvent,
+        hidePopup: hidePopup,
+        appearance: appearance,
+      ),
+    );
   }
 
   static Future<bool?> bootForWeb({

--- a/lib/channel_talk_flutter_method_channel.dart
+++ b/lib/channel_talk_flutter_method_channel.dart
@@ -58,6 +58,13 @@ class MethodChannelChannelTalkFlutter extends ChannelTalkFlutterPlatform {
   }
 
   @override
+  Future<ChannelTalkBootStatus> bootWithStatus(config) async {
+    final status =
+        await methodChannel.invokeMethod<String>('bootWithStatus', config);
+    return ChannelTalkBootStatus.fromNative(status);
+  }
+
+  @override
   Future<bool?> sleep() {
     return methodChannel.invokeMethod('sleep');
   }

--- a/lib/channel_talk_flutter_platform_interface.dart
+++ b/lib/channel_talk_flutter_platform_interface.dart
@@ -52,6 +52,10 @@ abstract class ChannelTalkFlutterPlatform extends PlatformInterface {
     throw UnimplementedError('boot() has not been implemented.');
   }
 
+  Future<ChannelTalkBootStatus> bootWithStatus(Map<String, dynamic> config) {
+    throw UnimplementedError('bootWithStatus() has not been implemented.');
+  }
+
   Future<bool?> sleep() {
     throw UnimplementedError('sleep() has not been implemented.');
   }

--- a/lib/channel_talk_flutter_web.dart
+++ b/lib/channel_talk_flutter_web.dart
@@ -81,6 +81,17 @@ class ChannelTalkFlutterWeb extends ChannelTalkFlutterPlatform {
   }
 
   @override
+  Future<ChannelTalkBootStatus> bootWithStatus(
+      Map<String, dynamic> config) async {
+    // Web ChannelIO boot does not surface a status; a completed boot maps to
+    // success.
+    final booted = await boot(config);
+    return booted == true
+        ? ChannelTalkBootStatus.success
+        : ChannelTalkBootStatus.unknown;
+  }
+
+  @override
   Future<bool?> shutdown() {
     channel_talk_service.shutdown('shutdown');
     return Future.value(true);

--- a/test/boot_with_status_test.dart
+++ b/test/boot_with_status_test.dart
@@ -1,0 +1,64 @@
+import 'package:channel_talk_flutter/channel_talk_flutter.dart';
+import 'package:channel_talk_flutter/channel_talk_flutter_method_channel.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('ChannelTalkBootStatus.fromNative', () {
+    test('round-trips every known status string', () {
+      for (final status in ChannelTalkBootStatus.values) {
+        expect(ChannelTalkBootStatus.fromNative(status.value), status);
+      }
+    });
+
+    test('falls back to unknown for null or unrecognized values', () {
+      expect(
+        ChannelTalkBootStatus.fromNative(null),
+        ChannelTalkBootStatus.unknown,
+      );
+      expect(
+        ChannelTalkBootStatus.fromNative('somethingElse'),
+        ChannelTalkBootStatus.unknown,
+      );
+    });
+  });
+
+  group('MethodChannelChannelTalkFlutter.bootWithStatus', () {
+    const channel = MethodChannel('channel_talk_flutter');
+    final platform = MethodChannelChannelTalkFlutter();
+    final log = <MethodCall>[];
+
+    tearDown(() {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, null);
+      log.clear();
+    });
+
+    test('invokes the "bootWithStatus" command and decodes the status',
+        () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (call) async {
+        log.add(call);
+        return 'networkTimeout';
+      });
+
+      final status = await platform.bootWithStatus({'pluginKey': 'k'});
+
+      expect(status, ChannelTalkBootStatus.networkTimeout);
+      expect(log.single.method, 'bootWithStatus');
+      expect((log.single.arguments as Map)['pluginKey'], 'k');
+    });
+
+    test('decodes an unrecognized native status as unknown', () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (call) async => 'weird');
+
+      expect(
+        await platform.bootWithStatus({'pluginKey': 'k'}),
+        ChannelTalkBootStatus.unknown,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## 개요

ChannelIO SDK의 boot는 실패 원인을 담은 `BootStatus`(iOS/Android)를 돌려주지만, 본 플러그인의 `boot()`는 이를 `bool`로 뭉개 실패 사유를 버립니다. 이 PR은 `boot()`를 그대로 두고, 상세 결과를 그대로 반환하는 `bootWithStatus()`를 추가합니다. 호출측이 transient 실패(예: `networkTimeout`, 재시도 가치 있음)와 permanent 실패(예: `accessDenied`, 포기)를 구분할 수 있게 합니다.

## 변경 내용

- `bootWithStatus()`를 추가했습니다. 반환 타입은 새 enum `ChannelTalkBootStatus`(non-null)이며, `boot()`와 동일한 인자를 받습니다.
- `ChannelTalkBootStatus`: `success` / `notInitialized` / `networkTimeout` / `notAvailableVersion` / `serviceUnderConstruction` / `requirePayment` / `accessDenied` / `unknown`. `fromNative(String?)`는 미매핑·null 값을 `unknown`으로 흡수합니다.
- 전 레이어에 반영했습니다: 공개 API → platform interface → method channel → iOS(Swift) / Android(Java) / Web.
- 네이티브는 `boot` / `bootWithStatus`가 단일 코어(`performBoot`)를 공유합니다. `ChannelIO.boot` 호출은 한 번뿐이며, `bootWithStatus`는 status 문자열을, `boot`는 그 결과를 기존 bool로 변환해 반환합니다.

## 동작 규칙

- **`boot()`의 기존 계약은 그대로입니다** — iOS는 실패 시 `false`, Android는 실패 시 `Execution failed(boot)` 에러, 양쪽 성공 시 `true`. (하위호환 유지)
- `bootWithStatus()`는 성공·실패 모두 해당하는 `ChannelTalkBootStatus`로 resolve합니다. `.success`이지만 user가 없는 경우는 `unknown`으로 보고합니다(`boot`의 엄격한 성공 기준과 일치).
- Web: web ChannelIO boot는 status를 제공하지 않으므로, boot 완료 시 `success`로 매핑합니다.

## SDK 버전

ChannelIO SDK 버전 변경은 없습니다. 현재 pin된 iOS `13.0.2`, Android `13.1.0`의 `BootStatus`를 그대로 사용합니다.

## 검증

- `flutter analyze` 통과
- `test/boot_with_status_test.dart` 추가: `ChannelTalkBootStatus.fromNative` 매핑 + method channel 디코드 (통과)